### PR TITLE
added options to configure keyring in api_call

### DIFF
--- a/R/api_call.R
+++ b/R/api_call.R
@@ -13,7 +13,8 @@ encode_pairs <- function(x) {
 }
 
 #' @importFrom jsonlite toJSON
-api_query <- function(query, collapse) {
+api_query <- function(query, collapse, 
+                      service = "openrouteservice", username = NULL, keyring = NULL) {
   # limit precision of numeric parameters to 6 decimal places
   query = rapply(query, how="replace", f = function(x) {
     if (is.numeric(x))
@@ -40,7 +41,7 @@ api_query <- function(query, collapse) {
   if ( !is.null(query$options) )
     query$options = toJSON(query$options, auto_unbox=TRUE)
 
-  c(api_key = ors_api_key(), query)
+  c(api_key = ors_api_key(service=service, username=username, keyring=keyring), query)
 }
 
 #' @importFrom httr status_code
@@ -64,7 +65,8 @@ rate_limited_call <- function (method, args) {
 #' @importFrom xml2 read_xml xml_validate
 api_call <- function(path, method, query = list(), ...,
                      response_format = c("json", "xml"),
-                     parse_output = NULL, simplifyMatrix = TRUE) {
+                     parse_output = NULL, simplifyMatrix = TRUE, 
+                     service = "openrouteservice", username = NULL, keyring = NULL) {
 
   method <- match.fun(method)
   response_format <- match.arg(response_format)
@@ -73,7 +75,8 @@ api_call <- function(path, method, query = list(), ...,
   collapse = ifelse (startsWith(path, 'geocode'), ',', '|')
 
   url <- getOption('openrouteservice.url', "https://api.openrouteservice.org")
-  url <- modify_url(url, path = path, query = api_query(query, collapse=collapse))
+  url <- modify_url(url, path = path, query = api_query(query, collapse=collapse, 
+                                                        service=service, username=username, keyring=keyring))
 
   res <- rate_limited_call(method, list(url, accept(type), user_agent("openrouteservice-r"), ...))
 

--- a/R/directions.R
+++ b/R/directions.R
@@ -24,6 +24,7 @@
 ors_directions <- function(coordinates,
                            profile = c('driving-car', 'driving-hgv', 'cycling-regular', 'cycling-road', 'cycling-safe', 'cycling-mountain', 'cycling-tour', 'cycling-electric', 'foot-walking', 'foot-hiking', 'wheelchair'),
                            format = c('json', 'geojson', 'gpx'),
+                           service = "openrouteservice", username = NULL, keyring = NULL,
                            ...,
                            parse_output = NULL) {
   if (missing(coordinates))
@@ -36,5 +37,6 @@ ors_directions <- function(coordinates,
 
   query = list(coordinates = coordinates, profile = profile, format = format, ...)
 
-  api_call("directions", "GET", query, response_format = response_format, parse_output = parse_output)
+  api_call("directions", "GET", query, response_format = response_format, parse_output = parse_output,
+           service=service, username=username, keyring=keyring)
 }

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -38,12 +38,15 @@
 #' y = ors_geocode(location = location, layers = "locality", size = 1)
 #'
 #' @export
-ors_geocode <- function(query, location, ..., parse_output = NULL) {
+ors_geocode <- function(query, location,
+                        service = "openrouteservice", username = NULL, keyring = NULL,
+                        ..., parse_output = NULL) {
   if ( missing(query) ) {
     if ( missing(location) )
       stop('Specify at least one of the arguments "query/location"')
     query <- list(point.lon = location[1L], point.lat = location[2L], ...)
-    api_call("geocode/reverse", "GET", query, parse_output = parse_output)
+    api_call("geocode/reverse", "GET", query, parse_output = parse_output,
+             service=service, username=username, keyring=keyring)
   }
   else {
     if ( length(query) > 1) {

--- a/R/isochrones.R
+++ b/R/isochrones.R
@@ -23,6 +23,7 @@
 ors_isochrones <- function(locations,
                            profile = c('driving-car', 'driving-hgv', 'cycling-regular', 'cycling-road', 'cycling-safe', 'cycling-mountain', 'cycling-tour', 'foot-walking', 'foot-hiking'),
                            range = 60,
+                           service = "openrouteservice", username = NULL, keyring = NULL,
                            ...,
                            parse_output = NULL) {
   if (missing(locations))
@@ -32,7 +33,8 @@ ors_isochrones <- function(locations,
 
   query = list(locations = locations, profile = profile, range = range, ...)
 
-  res = api_call("isochrones", "GET", query, simplifyMatrix=FALSE, parse_output = parse_output)
+  res = api_call("isochrones", "GET", query, simplifyMatrix=FALSE, parse_output = parse_output,
+                 service=service, username=username, keyring=keyring)
 
   if (inherits(res, "ors_api"))
     res$info$query$ranges = as.numeric(unlist(strsplit(res$info$query$ranges, ",")))

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -33,6 +33,7 @@
 ors_matrix <- function(locations,
                        profile = c('driving-car', 'driving-hgv', 'cycling-regular', 'cycling-road', 'cycling-safe', 'cycling-mountain', 'cycling-tour', 'cycling-electric', 'foot-walking', 'foot-hiking', 'wheelchair'),
                        metrics = c('distance', 'duration'),
+                       service = "openrouteservice", username = NULL, keyring = NULL,
                        ...,
                        parse_output = NULL) {
   if (missing(locations))
@@ -45,5 +46,6 @@ ors_matrix <- function(locations,
 
   body = list(locations = locations, profile = profile, metrics = metrics, ...)
 
-  api_call("matrix", "POST", body = body, encode = "json", parse_output = parse_output)
+  api_call("matrix", "POST", body = body, encode = "json", parse_output = parse_output,
+           service=service, username=username, keyring=keyring)
 }

--- a/R/pois.R
+++ b/R/pois.R
@@ -21,6 +21,7 @@
 #' @export
 ors_pois <- function(request = c('pois', 'stats', 'list'),
                      geometry,
+                     service = "openrouteservice", username = NULL, keyring = NULL,
                      ...,
                      parse_output = NULL) {
   request = match.arg(request)
@@ -34,5 +35,6 @@ ors_pois <- function(request = c('pois', 'stats', 'list'),
       body$geometry = geometry
   }
 
-  api_call("pois", "POST", body = body, encode = "json", parse_output = parse_output)
+  api_call("pois", "POST", body = body, encode = "json", parse_output = parse_output,
+           service=service, username=username, keyring=keyring)
 }


### PR DESCRIPTION
added options to configure access to the keyring (service, username and keyring) in api_call and api_query according to ors_api_key

I had difficulties using the keyring-API on my KDE neon User Edition 5.12 (KUbuntu 16.04). The default keyring (NULL) was not available and could not be set. The examples from the vignette did not work at all.

It is a bit counterintuitive, that service, username, and keyring can be configured in ors_api_key, but not when the API is actually called. These small amendments change this behavior without altering/breaking the current default.

By creating, unlocking and setting a keyring all problems are resolved. 
Create keyring: keyring::keyring_create(keyring = 'ORS')
Unlock keyring: keyring::keyring_unlock(keyring = 'ORS')
